### PR TITLE
tracking: fix '\xa0' character with replace ' ' in Device.age_text

### DIFF
--- a/tracking/models.py
+++ b/tracking/models.py
@@ -138,7 +138,7 @@ class Device(BasePoint):
     @property
     def age_text(self):
         # returns age in humanized form
-        return naturaltime(self.seen)
+        return naturaltime(self.seen).replace(u'\xa0', u' ')
 
     @property
     def icon(self):


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/resource_tracking/38)
<!-- Reviewable:end -->
