### PR TITLE
Upload observations mgmt command: prepend timeout to ltfp call to prevent endless retries on failure.

### DIFF
--- a/weather/management/commands/upload_cached_observations.py
+++ b/weather/management/commands/upload_cached_observations.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
                 # Use lftp to tranfer each file using SFTP.
                 try:
                     output = subprocess.check_output(
-                        ['lftp', connect_str, '-e', 'put -E {}; quit'.format(path)],
+                        ['timeout', '10', 'lftp', connect_str, '-e', 'put -E {}; quit'.format(path)],
                         stderr=subprocess.STDOUT)
                     logger.info('Uploaded {} to DAFWA'.format(f))
                 except subprocess.CalledProcessError:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/resource_tracking/68)
<!-- Reviewable:end -->
